### PR TITLE
task/loosen-up-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,10 +123,11 @@ jobs:
         run: bash ./gradlew --no-daemon clean test jacocoTestReport
 
       - name: Sonar Analysis
+        if: ${{ always() && !cancelled() }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonar
+        run: ./gradlew --no-daemon sonar -x test
 
       - name: Upload API test reports
         if: always()
@@ -139,6 +140,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload API coverage to Codecov
+        if: always()
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Loosen up CI to avoid pre-failures of SonarQube

## Why
- If Gradle fails, then it skips SonarQube despite a potential report to be made. Hence, we want SonarQube to run regardless.

## Testing
- [x] Mobile unit: `cd hive-maps/apps/mobile && npm run test:ci`
- [x] API unit: `cd hive-maps/services/api && ./gradlew test`
- [x] API smoke: `cd hive-maps/services/api && docker compose up -d --build` then `curl http://localhost:8080/api/hello`
- [ ] If any item is not applicable, explain why:

## Checklist
- [x] I kept this PR focused.
- [x] I added/updated tests where needed, or this change does not require tests.
- [x] I updated docs where needed, or this change does not require docs updates.
- [x] CI is green.
- [x] I have assigned the proper related items (reviewers, assignees, issues, branches, labels, etc)
