### PR TITLE
Add maestro scripts for US  3.1 and 3.2

### DIFF
--- a/hive-maps/apps/mobile/e2e/3.1_google_sign_in.yaml
+++ b/hive-maps/apps/mobile/e2e/3.1_google_sign_in.yaml
@@ -1,0 +1,15 @@
+appId: com.anonymous.mobile
+---
+- tapOn: "Calendar"
+- tapOn: "Connect Google Calendar"
+- tapOn: "mohamedmahmoud4123@gmail.com"
+- tapOn: "Continue"
+- tapOn: "Continue"
+- tapOn: "See and download any calendar you can access using your Google Calendar.\
+    \ Learn more"
+- scrollUntilVisible:
+      element:
+          text: "Continue"
+      direction: "DOWN"
+- tapOn: "Continue"
+- tapOn: "Disconnect"

--- a/hive-maps/apps/mobile/e2e/3.2_calendar_integration.yml
+++ b/hive-maps/apps/mobile/e2e/3.2_calendar_integration.yml
@@ -1,0 +1,45 @@
+appId: com.anonymous.mobile
+---
+- tapOn: "Calendar"
+- tapOn: "Connect Google Calendar"
+- tapOn:
+    id: "com.google.android.gms:id/account_name"
+- tapOn: "Continue"
+- extendedWaitUntil:
+    visible: "Sign in to Hivemaps"
+    timeout: 20000
+- tapOn: "Continue"
+- tapOn: "See and download any calendar you can access using your Google Calendar.\
+    \ Learn more"
+- scrollUntilVisible:
+    element:
+      text: "Continue"
+    direction: "DOWN"
+- tapOn: "Continue"
+- "scroll"
+- "scroll"
+- tapOn: "Refresh"
+- "scroll"
+- "scroll"
+- tapOn:
+    point: "16%,80%"
+- tapOn:
+    point: "16%,67%"
+- tapOn:
+    point: "16%,57%"
+- tapOn:
+    point: "16%,67%"
+- tapOn: "Refresh"
+- tapOn: "Export it with the Visual Schedule Builder extension"
+- extendedWaitUntil:
+    visible: "chrome web store"
+    timeout: 20000
+- swipe:
+    start: "50%, 98%"
+    end: "90%, 98%"
+    duration: 200
+- swipe:
+    start: "50%, 98%"
+    end: "90%, 98%"
+    duration: 200
+- tapOn: "Disconnect"


### PR DESCRIPTION
## Summary
- This PR adds the maestro testing scripts for US 3.1 and 3.2. The E2E videos are available in the wiki:
- 3.1: https://github.com/srabm/HiveMaps/wiki/06.-Testing-Plan-and-Report#us-31-e2e-testing-video
- 3.2: https://github.com/srabm/HiveMaps/wiki/06.-Testing-Plan-and-Report#us-32-e2e-testing-video

## Why
- Since it was missing in the US 3.2 PR

## Testing
- [x] Mobile unit: `cd hive-maps/apps/mobile && npm run test:ci`
- [x] API unit: `cd hive-maps/services/api && docker compose down -v && docker compose up -d --wait db && ./gradlew test`
- [x] API smoke: `cd hive-maps/services/api && docker compose up -d --build` then `curl http://localhost:8080/api/hello`
- [x] End-2-End Testing (script and screen-recording)
- [ ] If any item is not applicable, explain why:

## Checklist
- [x] I kept this PR focused.
- [x] I added/updated tests where needed, or this change does not require tests.
- [x] I updated docs where needed, or this change does not require docs updates.
- [x] I reviewed the acceptance criteria related to this user story and attached screenshots to the AT issue.
- [x] CI is green.
- [x] I have assigned the proper related items (reviewers, assignees, issues, branches, labels, etc)
