### PR TITLE
Bug/indoor_nav_UI

### DIFF
--- a/hive-maps/apps/mobile/__tests__/components/directions-bars.test.tsx
+++ b/hive-maps/apps/mobile/__tests__/components/directions-bars.test.tsx
@@ -357,6 +357,22 @@ describe("DirectionBar tests", () => {
     fireEvent.press(button);
     expect(onClose).toHaveBeenCalled();
   });
+
+  it('does not render the close button when onClose is not provided', () => {
+    const { queryByTestId } = render(
+      <DirectionBar
+        fromValue=''
+        toValue=''
+        onChangeFrom={jest.fn()}
+        onChangeTo={jest.fn()}
+        onSelectFrom={jest.fn()}
+        onSelectTo={jest.fn()}
+        onResetFrom={jest.fn()}
+      />
+    );
+
+    expect(queryByTestId('close-button')).toBeNull();
+  });
 });
 
 it("renders custom fromPlaceholder when provided", () => {

--- a/hive-maps/apps/mobile/__tests__/components/floor-plan-viewer.test.tsx
+++ b/hive-maps/apps/mobile/__tests__/components/floor-plan-viewer.test.tsx
@@ -752,8 +752,6 @@ describe('FloorPlanViewer', () => {
       expect(latestDirectionBarProps.fromValue).toBe('Current Location');
     });
 
-    mockFetchNearestNode.mockClear();
-
     act(() => {
       latestDirectionBarProps.onClearFrom();
     });
@@ -761,8 +759,6 @@ describe('FloorPlanViewer', () => {
     await waitFor(() => {
       expect(latestDirectionBarProps.fromValue).toBe('');
     });
-
-    expect(mockFetchNearestNode).not.toHaveBeenCalled();
   });
 
   it('handles fetchNearestNode rejection gracefully (no crash)', async () => {

--- a/hive-maps/apps/mobile/__tests__/components/floor-plan-viewer.test.tsx
+++ b/hive-maps/apps/mobile/__tests__/components/floor-plan-viewer.test.tsx
@@ -633,7 +633,7 @@ describe('FloorPlanViewer', () => {
 
   // ── selected room info card ───────────────────────────────────────────────
   it('shows selected room info card with label when a room is selected', () => {
-    const {getByTestId, getByText} = render(
+    const {queryByTestId} = render(
       <FloorPlanViewer
         planGeometry={makePlanGeometry()}
         rooms={makeRooms()}
@@ -643,13 +643,12 @@ describe('FloorPlanViewer', () => {
       />,
     );
 
-    expect(getByTestId('indoor-room-info-card')).toBeTruthy();
-    expect(getByText('Selected room: H-101')).toBeTruthy();
+    expect(queryByTestId('indoor-room-info-card')).toBeNull();
   });
 
   it('shows selectedRoomId as fallback when room has no label property', () => {
     const roomsNoLabel = makeRooms({label: undefined, name: undefined, code: undefined});
-    const {getByText} = render(
+    const {queryByTestId} = render(
       <FloorPlanViewer
         planGeometry={makePlanGeometry()}
         rooms={roomsNoLabel}
@@ -659,7 +658,7 @@ describe('FloorPlanViewer', () => {
       />,
     );
     // Feature id 123 is used as label fallback
-    expect(getByText('Selected room: 123')).toBeTruthy();
+    expect(queryByTestId('indoor-room-info-card')).toBeNull();
   });
 
   it('does not show info card when no room is selected', () => {
@@ -676,7 +675,7 @@ describe('FloorPlanViewer', () => {
 
   it('uses room name property as label when label is absent', () => {
     const roomsWithName = makeRooms({label: undefined, name: 'Lab 101'});
-    const {getByText} = render(
+    const {queryByTestId} = render(
       <FloorPlanViewer
         planGeometry={makePlanGeometry()}
         rooms={roomsWithName}
@@ -685,7 +684,7 @@ describe('FloorPlanViewer', () => {
         floorId="8"
       />,
     );
-    expect(getByText('Selected room: Lab 101')).toBeTruthy();
+    expect(queryByTestId('indoor-room-info-card')).toBeNull();
   });
 
   // ── nearest-node / user location ──────────────────────────────────────────
@@ -728,6 +727,37 @@ describe('FloorPlanViewer', () => {
 
     await act(async () => {
       latestUserLocationUpdate?.({coords: {longitude: -73.5799, latitude: 45.4903}});
+    });
+
+    expect(mockFetchNearestNode).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the start field empty after clearing Current Location', async () => {
+    mockFetchNearestNode.mockResolvedValue(makeNodeResponse('node-1'));
+
+    render(
+      <FloorPlanViewer
+        planGeometry={makePlanGeometry()}
+        rooms={makeRooms()}
+        buildingCode="H"
+        floorId="8"
+      />,
+    );
+
+    await act(async () => {
+      latestUserLocationUpdate?.({coords: {longitude: -73.5798, latitude: 45.4902}});
+    });
+
+    await waitFor(() => {
+      expect(latestDirectionBarProps.fromValue).toBe('Current Location');
+    });
+
+    act(() => {
+      latestDirectionBarProps.onClearFrom();
+    });
+
+    await waitFor(() => {
+      expect(latestDirectionBarProps.fromValue).toBe('');
     });
 
     expect(mockFetchNearestNode).toHaveBeenCalledTimes(1);
@@ -798,6 +828,19 @@ describe('FloorPlanViewer', () => {
       />,
     );
     expect(getByTestId('direction-bar')).toBeTruthy();
+  });
+
+  it('does not pass an onClose handler to the indoor direction bar', () => {
+    render(
+      <FloorPlanViewer
+        planGeometry={makePlanGeometry()}
+        rooms={makeRooms()}
+        buildingCode="H"
+        floorId="8"
+      />,
+    );
+
+    expect(latestDirectionBarProps.onClose).toBeUndefined();
   });
 
   // ── POI destination tap ────────────────────────────────────────────────────
@@ -1055,6 +1098,47 @@ describe('FloorPlanViewer', () => {
     });
   });
 
+  it('clears both endpoints when the pre-start modal is cancelled', async () => {
+    mockFetchIndoorDirections.mockResolvedValue(makeIndoorSteps());
+
+    const {getByTestId, queryByTestId} = render(
+      <FloorPlanViewer
+        planGeometry={makePlanGeometry()}
+        rooms={makeRooms()}
+        onPressRoom={jest.fn()}
+        buildingCode="H"
+        floorId="8"
+      />,
+    );
+
+    await act(async () => {
+      latestRoomsPressHandler?.({
+        features: [{properties: {nodeID: 'node-from', roomId: 'room-1'}}],
+      });
+    });
+
+    await act(async () => {
+      latestRoomsPressHandler?.({
+        features: [{properties: {nodeID: 'node-to', roomId: 'room-2'}}],
+      });
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('directions-modal')).toBeTruthy();
+    });
+
+    act(() => {
+      latestDirectionsModalProps.onCancel?.();
+    });
+
+    await waitFor(() => {
+      expect(queryByTestId('directions-modal')).toBeNull();
+    });
+
+    expect(latestDirectionBarProps.fromValue).toBe('');
+    expect(latestDirectionBarProps.toValue).toBe('');
+  });
+
   it('uses "Navigate" pre-start label when accessibility mode is enabled', async () => {
     mockAccessible = true;
     mockFetchIndoorDirections.mockResolvedValue(makeIndoorSteps());
@@ -1263,7 +1347,7 @@ describe('FloorPlanViewer', () => {
     expect(latestDirectionBarProps.toValue).toBe('From A');
   });
 
-  it('does not apply stale POI lookup result after closing direction bar', async () => {
+  it('does not apply stale POI lookup result after clearing destination', async () => {
     let resolvePoiLookup: ((value: ReturnType<typeof makeNodeResponse>) => void) | null = null;
     mockFetchNearestNode.mockImplementation(
       () => new Promise((resolve) => {
@@ -1283,7 +1367,7 @@ describe('FloorPlanViewer', () => {
     fireEvent.press(getByTestId('indoor-poi-marker-poi-fallback-0'));
 
     act(() => {
-      latestDirectionBarProps.onClose();
+      latestDirectionBarProps.onClearTo();
     });
 
     expect(latestDirectionBarProps.toValue).toBe('');
@@ -1750,7 +1834,7 @@ describe('FloorPlanViewer', () => {
     expect(latestDirectionBarProps.toValue).toBe('Room A');
   });
 
-  it('onClose clears both fromQuery and toQuery', () => {
+  it('clearing both fields resets fromQuery and toQuery', () => {
     render(
       <FloorPlanViewer
         planGeometry={makePlanGeometry()}
@@ -1767,7 +1851,8 @@ describe('FloorPlanViewer', () => {
       latestDirectionBarProps.onSelectTo({name: 'Room B', id: 'node-B'}, undefined);
     });
     act(() => {
-      latestDirectionBarProps.onClose();
+      latestDirectionBarProps.onClearFrom();
+      latestDirectionBarProps.onClearTo();
     });
 
     expect(latestDirectionBarProps.fromValue).toBe('');

--- a/hive-maps/apps/mobile/__tests__/components/floor-plan-viewer.test.tsx
+++ b/hive-maps/apps/mobile/__tests__/components/floor-plan-viewer.test.tsx
@@ -752,6 +752,8 @@ describe('FloorPlanViewer', () => {
       expect(latestDirectionBarProps.fromValue).toBe('Current Location');
     });
 
+    mockFetchNearestNode.mockClear();
+
     act(() => {
       latestDirectionBarProps.onClearFrom();
     });
@@ -760,7 +762,7 @@ describe('FloorPlanViewer', () => {
       expect(latestDirectionBarProps.fromValue).toBe('');
     });
 
-    expect(mockFetchNearestNode).toHaveBeenCalledTimes(1);
+    expect(mockFetchNearestNode).not.toHaveBeenCalled();
   });
 
   it('handles fetchNearestNode rejection gracefully (no crash)', async () => {

--- a/hive-maps/apps/mobile/__tests__/components/indoor-directions-modal.test.tsx
+++ b/hive-maps/apps/mobile/__tests__/components/indoor-directions-modal.test.tsx
@@ -67,6 +67,7 @@ describe('DirectionsModal', () => {
         const {getByText} = renderModal();
         expect(getByText('Walk')).toBeTruthy();
         expect(getByText('Start')).toBeTruthy();
+        expect(getByText('Cancel')).toBeTruthy();
     });
 
     it('shows destination label on the pre-start screen', () => {
@@ -271,6 +272,20 @@ describe('DirectionsModal', () => {
         const { getByText } = renderModal({ onClose });
         fireEvent.press(getByText('Start'));
         fireEvent.press(getByText('End'));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onCancel when Cancel is pressed on the pre-start screen', () => {
+        const onCancel = jest.fn();
+        const { getByText } = renderModal({ onCancel });
+        fireEvent.press(getByText('Cancel'));
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to onClose when Cancel is pressed without an onCancel handler', () => {
+        const onClose = jest.fn();
+        const { getByText } = renderModal({ onClose });
+        fireEvent.press(getByText('Cancel'));
         expect(onClose).toHaveBeenCalledTimes(1);
     });
 

--- a/hive-maps/apps/mobile/components/directions-bars.tsx
+++ b/hive-maps/apps/mobile/components/directions-bars.tsx
@@ -177,9 +177,11 @@ const DirectionBar: React.FC<DirectionBarProps> = ({
                 </View>
 
                 <View style={styles.controls}>
-                    <TouchableOpacity testID="close-button" onPress={onClose} style={styles.closeButton}>
-                        <Ionicons name="close" size={24} color="#000" />
-                    </TouchableOpacity>
+                    {onClose ? (
+                        <TouchableOpacity testID="close-button" onPress={onClose} style={styles.closeButton}>
+                            <Ionicons name="close" size={24} color="#000" />
+                        </TouchableOpacity>
+                    ) : null}
 
                     <TouchableOpacity testID="swap-button" onPress={onSwap} style={styles.swapButton}>
                         <Ionicons name="swap-vertical" size={22} />

--- a/hive-maps/apps/mobile/components/indoor/floor-plan-viewer.tsx
+++ b/hive-maps/apps/mobile/components/indoor/floor-plan-viewer.tsx
@@ -437,6 +437,9 @@ export function FloorPlanViewer({
     const nearestNodeResolvedRef = useRef(Boolean(initialFromNodeId));
     // Track which floor context the fromNodeId was auto-resolved for (so we reset on floor/building change)
     const autoResolvedContextRef = useRef<string | null>(null);
+    const allowAutoResolveFromLocationRef = useRef(
+        !initialFromNodeId || initialFromQuery === 'Current Location'
+    );
     const resolveNearestNode = useCallback(async (longitude: number, latitude: number) => {
         try {
             const node = await fetchNearestNode(buildingCode, floorId, longitude, latitude);
@@ -449,6 +452,34 @@ export function FloorPlanViewer({
             setFromQuery('');
         }
     }, [buildingCode, floorId]);
+
+    const disableAutoResolvedStart = useCallback(() => {
+        allowAutoResolveFromLocationRef.current = false;
+        autoResolvedContextRef.current = null;
+        nearestNodeResolvedRef.current = true;
+    }, []);
+
+    const clearStartSelection = useCallback(() => {
+        disableAutoResolvedStart();
+        setFromQuery('');
+        setFromNodeId(null);
+    }, [disableAutoResolvedStart]);
+
+    const resetStartToCurrentLocation = useCallback(() => {
+        allowAutoResolveFromLocationRef.current = true;
+        autoResolvedContextRef.current = null;
+        setFromQuery('');
+        setFromNodeId(null);
+
+        const coords = userCoordsRef.current;
+        if (coords) {
+            nearestNodeResolvedRef.current = true;
+            void resolveNearestNode(coords[0], coords[1]);
+            return;
+        }
+
+        nearestNodeResolvedRef.current = false;
+    }, [resolveNearestNode]);
 
     const resolveDirections = useCallback(async (fromNodeId: string, toNodeId: string, accessible: boolean, fromText: string, toText: string) => {
         try {
@@ -476,7 +507,7 @@ export function FloorPlanViewer({
             setFromNodeId(null);
             setFromQuery('');
             const coords = userCoordsRef.current;
-            if (coords) {
+            if (coords && allowAutoResolveFromLocationRef.current) {
                 nearestNodeResolvedRef.current = true;
                 resolveNearestNode(coords[0], coords[1]);
             }
@@ -487,6 +518,10 @@ export function FloorPlanViewer({
             return;
         }
         if (indoorSteps) return;
+        if (!allowAutoResolveFromLocationRef.current) {
+            nearestNodeResolvedRef.current = true;
+            return;
+        }
         nearestNodeResolvedRef.current = false;
         const coords = userCoordsRef.current;
         if (coords) {
@@ -527,7 +562,12 @@ export function FloorPlanViewer({
         const latitude: number = coords.latitude;
         userCoordsRef.current = [longitude, latitude];
         // Only trigger nearest-node once per floor load
-        if (!nearestNodeResolvedRef.current && !indoorSteps && !fromNodeId) {
+        if (
+            allowAutoResolveFromLocationRef.current &&
+            !nearestNodeResolvedRef.current &&
+            !indoorSteps &&
+            !fromNodeId
+        ) {
             nearestNodeResolvedRef.current = true;
             resolveNearestNode(longitude, latitude);
         }
@@ -893,6 +933,19 @@ export function FloorPlanViewer({
                 setToNodeId(null);
                 invalidatePendingPoiSelection();
             }}
+            onCancel={() => {
+                if (resumeSessionId || completeSessionId) {
+                    router.back();
+                    return;
+                }
+                setIndoorSteps(null);
+                setCurrentNode(null);
+                setFromQuery('');
+                setFromNodeId(null);
+                setToQuery('');
+                setToNodeId(null);
+                invalidatePendingPoiSelection();
+            }}
             preStartLabel={accessible ? "Navigate" : undefined}
             autoStart={autoStartNavigation}
             stairsNotice={stairsNotice}
@@ -907,12 +960,18 @@ export function FloorPlanViewer({
             mapsAdapter={nodeAdapter}
             fromValue={fromQuery}
             toValue={toQuery}
-            onChangeFrom={setFromQuery}
+            onChangeFrom={(text) => {
+              disableAutoResolvedStart();
+              setFromQuery(text);
+              setFromNodeId(null);
+            }}
             onChangeTo={(text) => {
               setToQuery(text);
+              setToNodeId(null);
               invalidatePendingPoiSelection();
             }}
             onSelectFrom={(mapLocation, coordinates) => {
+              disableAutoResolvedStart();
               setFromQuery(mapLocation.name);
               setFromNodeId(mapLocation.id);
               if (coordinates) cameraRef.current?.setCamera({
@@ -932,32 +991,22 @@ export function FloorPlanViewer({
               });
             }}
             onClearFrom={() => {
-              setFromQuery('');
-              setFromNodeId(null);
+              clearStartSelection();
             }}
             onClearTo={() => {
               setToQuery('');
               setToNodeId(null);
               invalidatePendingPoiSelection();
             }}
-            onResetFrom={() => {
-              setFromQuery('');
-              setFromNodeId(null);
-            }}
+            onResetFrom={resetStartToCurrentLocation}
             onSwap={() => {
               const tempQuery = fromQuery;
               const tempNodeId = fromNodeId;
+              disableAutoResolvedStart();
               setFromQuery(toQuery);
               setFromNodeId(toNodeId);
               setToQuery(tempQuery);
               setToNodeId(tempNodeId);
-              invalidatePendingPoiSelection();
-            }}
-            onClose={() => {
-              setFromQuery('');
-              setFromNodeId(null);
-              setToQuery('');
-              setToNodeId(null);
               invalidatePendingPoiSelection();
             }}
             fromPlaceholder="From room (e.g. H8.835)"
@@ -969,14 +1018,6 @@ export function FloorPlanViewer({
               onToggle={setAccessible}
             />
           </View>
-        </View>
-      )}
-
-      {selectedRoomId && (
-        <View testID="indoor-room-info-card" style={styles.infoCard}>
-          <Text testID="indoor-selected-room-label" style={styles.infoCardText}>
-            {selectedRoomLabel ? `Selected room: ${selectedRoomLabel}` : `Selected room: ${selectedRoomId}`}
-          </Text>
         </View>
       )}
     </View>
@@ -993,22 +1034,6 @@ const styles = StyleSheet.create({
         fontStyle: 'italic',
         alignSelf: 'center',
         marginTop: 20,
-    },
-    infoCard: {
-        position: 'absolute',
-        left: 12,
-        right: 12,
-        bottom: 12,
-        borderRadius: 10,
-        paddingVertical: 10,
-        paddingHorizontal: 12,
-        backgroundColor: '#fff',
-        borderWidth: 1,
-        borderColor: '#d1d5db',
-    },
-    infoCardText: {
-        color: '#111827',
-        fontWeight: '600',
     },
     directionBarContainer: {
         position: 'absolute',

--- a/hive-maps/apps/mobile/components/indoor/indoor-directions-modal.tsx
+++ b/hive-maps/apps/mobile/components/indoor/indoor-directions-modal.tsx
@@ -77,6 +77,7 @@ export interface DirectionsModalProps {
     origin?: string;
     destination?: string;
     onClose: () => void;
+    onCancel?: () => void;
     onArrived?: () => void;
     onCurrentNodeChange?: (node: IndoorNodeResponse) => void;
     beeImageSource?: any;
@@ -156,6 +157,7 @@ const DirectionsModal: React.FC<DirectionsModalProps> = ({
     origin = "Your location",
     destination,
     onClose,
+    onCancel,
     onArrived,
     onCurrentNodeChange,
     beeImageSource,
@@ -370,9 +372,14 @@ const DirectionsModal: React.FC<DirectionsModalProps> = ({
                     <Text style={styles.preStartArrive}>Arrive at {destLabel}</Text>
                     <Text style={styles.preStartDist}>{augmentedSteps.reduce((sum, s) => sum + s.distance, 0).toFixed(0)} m</Text>
                 </View>
-                            <TouchableOpacity style={styles.startBtn} onPress={() => { setHasArrived(false); setHasStarted(true); }}>
-                                <Text style={styles.startBtnText}>Start</Text>
-                            </TouchableOpacity>
+                <View style={styles.preStartActions}>
+                    <TouchableOpacity style={styles.cancelBtn} onPress={onCancel ?? onClose}>
+                        <Text style={styles.cancelBtnText}>Cancel</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity style={styles.startBtn} onPress={() => { setHasArrived(false); setHasStarted(true); }}>
+                        <Text style={styles.startBtnText}>Start</Text>
+                    </TouchableOpacity>
+                </View>
             </View>
         </View>
     );
@@ -510,6 +517,14 @@ const styles = StyleSheet.create({
     preStartInfo: { flex: 1 },
     preStartArrive: { fontSize: 14, fontWeight: "600", color: DARK },
     preStartDist: { fontSize: 12, color: MUTED, marginTop: 2 },
+    preStartActions: { flexDirection: "row", alignItems: "center", gap: 8 },
+    cancelBtn: {
+        backgroundColor: "#F3F4F6",
+        borderRadius: 12,
+        paddingVertical: 9,
+        paddingHorizontal: 14,
+    },
+    cancelBtnText: { color: "#374151", fontSize: 14, fontWeight: "700" },
     startBtn: { backgroundColor: "#9d1e30", borderRadius: 12, paddingVertical: 9, paddingHorizontal: 18 },
     startBtnText: { color: BG, fontSize: 14, fontWeight: "700" },
     bottomBar: {


### PR DESCRIPTION
## Summary
  - Fix indoor navigation UX by adding a cancel path before auto-started turn-by-turn navigation
  - Remove the redundant selected-room card from the indoor map screen
  - Make the indoor start field clearable without re-inserting Current Location
  - Hide the indoor navigation bar close button when no close action exists

## Why
  - Users could get trapped in indoor navigation after selecting classroom endpoints
  - The selected-room card obscured the floor indicator without adding useful information
  - Clearing Current Location was ineffective because auto-resolve immediately restored it
  - The indoor close button suggested a dismiss action that did nothing in practice

## Testing
- [x] Mobile unit: `cd hive-maps/apps/mobile && npm run test:ci`
- [x] API unit: `cd hive-maps/services/api && docker compose down -v && docker compose up -d --wait db && ./gradlew test`
- [x] API smoke: `cd hive-maps/services/api && docker compose up -d --build` then `curl http://localhost:8080/api/hello`
- [ ] End-2-End Testing (script and screen-recording)
- [ ] If any item is not applicable, explain why:

## Checklist
- [x] I kept this PR focused.
- [x] I added/updated tests where needed, or this change does not require tests.
- [x] I updated docs where needed, or this change does not require docs updates.
- [ ] I reviewed the acceptance criteria related to this user story and attached screenshots to the AT issue.
- [ ] CI is green.
- [ ] I have assigned the proper related items (reviewers, assignees, issues, branches, labels, etc)
